### PR TITLE
Actually queries each IP address (which is good)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pdig-dns-tool
 Python implemention of dig that checks all servers recording latency
 
-Many people use dig +trace to check the authorities and delegations, but when you want to check them all, I wanted a easy way to do this but also know per-server, per-address-family (AF_INET6 vs AF_INET) to make it easier to identify outliers.  This tool will help you with that and give some basic statistics on a per-delegation level.  It also will follow CNAMEs it encounters in the chain, but does it in a "return to the root" sort of way which while not ideal, helps get metrics on what a cold cache client might experience at each delegation point.
+Many people use dig +trace to check the authorities and delegations, but when you want to check them all, I wanted a easy way to do this but also know per-server, per-address-family (AF_INET6 vs AF_INET), per IP address to make it easier to identify outliers.  This tool will help you with that and give some basic statistics on a per-delegation level.  It also will follow CNAMEs it encounters in the chain, but does it in a "return to the root" sort of way which while not ideal, helps get metrics on what a cold cache client might experience at each delegation point.
 
 I may make a presentation on this for a community like DNS-OARC in the future.
 

--- a/pdig-dns-tool.py
+++ b/pdig-dns-tool.py
@@ -3,7 +3,7 @@
 """
 # ask each NS in the query for the domainname
 # for answers and record response times for
-# each AF, transport and authority
+# each address family, IP address, transport and authority
 
 """
 


### PR DESCRIPTION
The tool queries not only every AF but also every IP address (which is right, per RFC 1034, section 4.3.2) so this patch documents it.

```
% ./pdig-dns-tool.py cloudflare.com 
…
===================
ns=ns3.cloudflare.com. addr=162.159.0.33, latency=6.396 ms
ns=ns3.cloudflare.com. addr=162.159.7.226, latency=6.178 ms
ns=ns3.cloudflare.com. addr=2400:cb00:2049:1::a29f:7e2, latency=6.355 ms
ns=ns3.cloudflare.com. addr=2400:cb00:2049:1::a29f:21, latency=6.704 ms
ns=ns5.cloudflare.com. addr=162.159.9.55, latency=6.356 ms
ns=ns5.cloudflare.com. addr=162.159.2.9, latency=6.200 ms
ns=ns5.cloudflare.com. addr=2400:cb00:2049:1::a29f:209, latency=6.948 ms
ns=ns5.cloudflare.com. addr=2400:cb00:2049:1::a29f:937, latency=7.175 ms
ns=ns4.cloudflare.com. addr=162.159.8.55, latency=6.369 ms
ns=ns4.cloudflare.com. addr=162.159.1.33, latency=6.101 ms
ns=ns4.cloudflare.com. addr=2400:cb00:2049:1::a29f:837, latency=6.359 ms
ns=ns4.cloudflare.com. addr=2400:cb00:2049:1::a29f:121, latency=6.405 ms
ns=ns6.cloudflare.com. addr=162.159.3.11, latency=7.302 ms
ns=ns6.cloudflare.com. addr=162.159.5.6, latency=5.969 ms
ns=ns6.cloudflare.com. addr=2400:cb00:2049:1::a29f:506, latency=6.740 ms
ns=ns6.cloudflare.com. addr=2400:cb00:2049:1::a29f:30b, latency=6.933 ms
ns=ns7.cloudflare.com. addr=162.159.4.8, latency=5.789 ms
ns=ns7.cloudflare.com. addr=162.159.6.6, latency=5.613 ms
ns=ns7.cloudflare.com. addr=2400:cb00:2049:1::a29f:606, latency=6.162 ms
ns=ns7.cloudflare.com. addr=2400:cb00:2049:1::a29f:408, latency=6.258 ms
latency: min=5.613 ms max=7.302 ms avg=6.416 ms
stdev=0.438 ms max-min=1.689 max/min=1.30 x latency variance
===================
end=Sat Feb 22 10:50:22 2025
```
