### PR TITLE
Handle response codes ≠ NOERROR. Closes #2

### DIFF
--- a/pdig-dns-tool.py
+++ b/pdig-dns-tool.py
@@ -43,6 +43,7 @@ def query_all(full_qname, prev_cache, qtype_list):
     new_cache = []
     times = []
     query_ip = {}
+    domain_exists = True
 
     for qtype in qtype_list:
         try:
@@ -72,6 +73,12 @@ def query_all(full_qname, prev_cache, qtype_list):
                     times.append(latency_ms)
 
                     print(f"ns={x['qname']} addr={x['addrinfo']}, latency={latency_ms:.3f} ms")
+                    if resp.rcode() == dns.rcode.NXDOMAIN:
+                        domain_exists = False
+                        continue
+                    if resp.rcode() != dns.rcode.NOERROR:
+                        print(f"{dns.rcode.to_text(resp.rcode())} for {full_qname} at {x['addrinfo']}")
+                        continue
                     if len(resp.answer) > 0:
                         # 5 = CNAME rfc1035
                         if resp.answer[0].rdtype == 5:
@@ -114,6 +121,9 @@ def query_all(full_qname, prev_cache, qtype_list):
     min_max_ratio = max_value / min_value
     print(f"latency: min={min_value:.3f} ms max={max_value:.3f} ms avg={avg_value:.3f} ms")
     print(f"stdev={stddev:.3f} ms max-min={min_max_range:.3f} max/min={min_max_ratio:.2f} x latency variance")
+    if not domain_exists:
+        print(f"NXDOMAIN for {full_qname}, stopping…")
+        return ([], None)
     return (new_cache, cname_reply)
 
 root_hints = []


### PR DESCRIPTION
Note: it displays more text so if someone was parsing the text of a previous version, it can change things. Is it a good idea?

Example with NXDOMAIN:

```
% ./pdig-dns-tool.py certainlydoesnotexist.com
…
===================
ns=c.gtld-servers.net. addr=192.26.92.30, latency=15.392 ms
ns=c.gtld-servers.net. addr=2001:503:83eb::30, latency=15.520 ms
ns=i.gtld-servers.net. addr=192.43.172.30, latency=20.405 ms
ns=i.gtld-servers.net. addr=2001:503:39c1::30, latency=14.775 ms
ns=f.gtld-servers.net. addr=192.35.51.30, latency=19.975 ms
ns=f.gtld-servers.net. addr=2001:503:d414::30, latency=14.225 ms
ns=k.gtld-servers.net. addr=192.52.178.30, latency=19.406 ms
ns=k.gtld-servers.net. addr=2001:503:d2d::30, latency=6.722 ms
ns=l.gtld-servers.net. addr=192.41.162.30, latency=19.008 ms
ns=l.gtld-servers.net. addr=2001:500:d937::30, latency=7.168 ms
ns=m.gtld-servers.net. addr=192.55.83.30, latency=21.257 ms
ns=m.gtld-servers.net. addr=2001:501:b1f9::30, latency=8.043 ms
ns=d.gtld-servers.net. addr=192.31.80.30, latency=14.389 ms
ns=d.gtld-servers.net. addr=2001:500:856e::30, latency=15.843 ms
ns=b.gtld-servers.net. addr=192.33.14.30, latency=6.797 ms
ns=b.gtld-servers.net. addr=2001:503:231d::2:30, latency=7.122 ms
ns=g.gtld-servers.net. addr=192.42.93.30, latency=20.074 ms
ns=g.gtld-servers.net. addr=2001:503:eea3::30, latency=13.735 ms
ns=a.gtld-servers.net. addr=192.5.6.30, latency=15.046 ms
ns=a.gtld-servers.net. addr=2001:503:a83e::2:30, latency=16.896 ms
ns=e.gtld-servers.net. addr=192.12.94.30, latency=14.224 ms
ns=e.gtld-servers.net. addr=2001:502:1ca1::30, latency=14.428 ms
ns=j.gtld-servers.net. addr=192.48.79.30, latency=19.493 ms
ns=j.gtld-servers.net. addr=2001:502:7094::30, latency=8.204 ms
ns=h.gtld-servers.net. addr=192.54.112.30, latency=20.241 ms
ns=h.gtld-servers.net. addr=2001:502:8cc::30, latency=13.910 ms
latency: min=6.722 ms max=21.257 ms avg=14.704 ms
stdev=4.745 ms max-min=14.535 max/min=3.16 x latency variance
NXDOMAIN for certainlydoesnotexist.com, stopping…
===================
end=Sat Feb 22 11:15:10 2025
/tmp/977tz3j_
```

And for other errors:

```
% ./pdig-dns-tool.py gouv.ci                  
…
==================
ns=ci.hosting.nic.fr. addr=192.134.0.49, latency=6.745 ms
ns=ci.hosting.nic.fr. addr=2001:660:3006:1::1:1, latency=10.183 ms
ns=ns.nic.ci. addr=196.49.0.84, latency=104.748 ms
ns=any.nic.ci. addr=204.61.216.120, latency=5.705 ms
ns=any.nic.ci. addr=2001:500:14:6120:ad::1, latency=7.102 ms
ns=ns-ci.afrinic.net. addr=196.216.168.30, latency=188.501 ms
ns=ns-ci.afrinic.net. addr=2001:43f8:120::30, latency=183.053 ms
ns=phloem.uoregon.edu. addr=128.223.32.35, latency=152.417 ms
SERVFAIL for gouv.ci at 128.223.32.35
timeout querying: 2001:468:d01:20::80df:2023
latency: min=5.705 ms max=188.501 ms avg=82.307 ms
stdev=83.906 ms max-min=182.796 max/min=33.04 x latency variance
===================
…
```

