### PR TITLE
Add PEP 723 script metadata of dependencies

### DIFF
--- a/pdig-dns-tool.py
+++ b/pdig-dns-tool.py
@@ -1,4 +1,10 @@
 #!/usr/bin/python3
+# /// script
+# dependencies = [
+#     "dnspython",
+#     "requests",
+# ]
+# ///
 
 """
 # ask each NS in the query for the domainname


### PR DESCRIPTION
This allows various tools to know the dependencies needed, automatically.